### PR TITLE
Updated User model to comply with sails v1.0

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -19,8 +19,10 @@ module.exports = {
       required: true
     },
     email: {
-      type: 'email',
+      type: 'string',
       unique: true,
+      required: true,
+      isEmail: true,
     },
     passports: {
       collection: 'Passport',


### PR DESCRIPTION
Updated User model to comply with sails v1.0, where email is no longer a type. Email types are now type string, with isEmail: true